### PR TITLE
[FEATURE] add exactly once case

### DIFF
--- a/.github/workflows/kop-test-per-hour.yml
+++ b/.github/workflows/kop-test-per-hour.yml
@@ -17,7 +17,7 @@ env:
   GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
 
 jobs:
-  alt-chao:
+  alo-chao:
     runs-on: ubuntu-latest
     env:
       REPO_PATH: ${{ github.workspace }}
@@ -181,7 +181,7 @@ jobs:
       matrix:
         test: [
           {
-            name: "idempotence-transaction",
+            name: "idempotence-no-transaction",
             chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-idem-network-delay.yaml"
           }
         ]

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  alt-chao:
+  alo-chao:
     runs-on: ubuntu-latest
     env:
       JAVA_VERSION: 17
@@ -180,9 +180,116 @@ jobs:
       matrix:
         test: [
           {
-            name: "idempotence-transaction",
+            name: "idempotence-no-transaction",
             chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-idem-network-delay.yaml"
           }
+        ]
+
+    steps:
+      - name: Checkout chao-test codebase
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+      - name: Build
+        run: mvn clean package
+      - name: Build docker
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          tags: chao-test:latest
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.ASCENTSTREAM_DOCKER_USERNAME }}
+          password: ${{ secrets.ASCENTSTREAM_DOCKER_PASSWORD }}
+
+      - uses: helm/kind-action@v1.5.0
+        with:
+          cluster_name: kind
+          kubectl_version: v1.25.5
+
+      - name: deploy as-platform
+        run: ${{ env.REPO_PATH }}/scripts/ci.sh deploy_as_platform
+      - name: deploy chaos-mesh
+        run: |
+          curl -sSL https://mirrors.chaos-mesh.org/v2.7.0/install.sh | bash -s -- --local kind --kind-version v0.17.0 --name kind  --k8s-version  1.25.3
+          kubectl get pod  -n chaos-mesh
+      - name: ${{ matrix.test.name }}
+        run: |
+          kind load docker-image chao-test:latest
+          ${{ env.REPO_PATH }}/scripts/run-chao-test.sh
+          kubectl -n pulsar-cluster get pods
+      - name: injecting faults
+        run: |
+          sleep 30
+          kubectl -n chaos-mesh apply -f ${{ matrix.test.chaos-mesh-config }}
+          echo "get chaos-mesh workflow "
+          kubectl -n chaos-mesh get workflow
+          echo "get chaos-mesh workflownode "
+          kubectl -n chaos-mesh get workflownode --selector="chaos-mesh.org/workflow=asp-platform"
+      - name: Wait for workflow completion
+        run: ${{ env.REPO_PATH }}/scripts/wait-workflow-completion.sh
+
+      - name: package reports
+        if: failure()
+        run: |
+          rm -rf artifacts
+          mkdir artifacts
+          mkdir artifacts/chao-test
+          mkdir artifacts/pulsar
+          current_dir=$PWD
+          kubectl -n pulsar-cluster logs chao-test > ${current_dir}/artifacts/chao-test/chao-test.log
+          ${{ env.REPO_PATH }}/scripts/cp-logs-from-kind.sh  ${current_dir}/artifacts/chao-test
+          kubectl -n pulsar-cluster logs pulsar-asp-broker-0 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-0.log
+          kubectl -n pulsar-cluster logs pulsar-asp-broker-1 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-1.log
+          kubectl -n pulsar-cluster logs pulsar-asp-bookie-0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-0.log
+          kubectl -n pulsar-cluster logs pulsar-asp-bookie-1 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-1.log
+          kubectl -n pulsar-cluster logs pulsar-asp-bookie-2 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-2.log
+          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-0.log
+          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-1 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-1.log
+          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-2 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-2.log
+          zip -r artifacts-${{ matrix.test.name }}.zip artifacts
+
+      - uses: actions/upload-artifact@master
+        name: upload reports
+        if: failure()
+        with:
+          name: artifacts-${{ matrix.test.name }}
+          path: artifacts-${{ matrix.test.name }}.zip
+
+  eo-chao:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_VERSION: 17
+      JAVA_DISTRIBUTION: temurin
+      REPO_PATH: ${{ github.workspace }}
+      AS_PLATFORM_IMAGE_TAG: chao-test-latest
+      REGISTRY_USERNAME: ${{ secrets.ASCENTSTREAM_DOCKER_USERNAME }}
+      REGISTRY_PASSWORD: ${{ secrets.ASCENTSTREAM_DOCKER_PASSWORD }}
+      KAFKA_BOOTSTRAP_SERVERS: pulsar-asp-broker-headless:9092
+      SEND_MSG_COUNT: 1000
+      TOPIC: transaction-1,transaction-2
+      TOPIC_PARTITION: 10
+      MAX_WAITING_TIME: 600
+      MAIN_CLASS: com.ascentsream.tests.kop.ExactlyOnceMessaging
+
+    strategy:
+      # other jobs should run even if one test fails
+      fail-fast: false
+      matrix:
+        test: [
+          {
+            name: "eo-normal",
+            chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-no-chaos.yaml"
+          },
+          {
+            name: "eo-pod-chaos",
+            chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-exactly-pod-chaos.yaml"
+          },
         ]
 
     steps:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -287,8 +287,12 @@ jobs:
             chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-no-chaos.yaml"
           },
           {
-            name: "eo-pod-chaos",
+            name: "eo-chaos-pod",
             chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-exactly-pod-chaos.yaml"
+          },
+          {
+            name: "eo-chaos-network-delay",",
+            chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-idem-network-delay.yaml"
           },
         ]
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -291,9 +291,9 @@ jobs:
             chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-exactly-pod-chaos.yaml"
           },
           {
-            name: "eo-chaos-network-delay",",
+            name: "eo-chaos-network-delay",
             chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-idem-network-delay.yaml"
-          },
+          }
         ]
 
     steps:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -288,12 +288,40 @@ jobs:
           },
           {
             name: "eo-chaos-pod",
-            chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-exactly-pod-chaos.yaml"
+            chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-pod-chaos.yaml"
           },
           {
             name: "eo-chaos-network-delay",
-            chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-idem-network-delay.yaml"
-          }
+            chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-network-delay.yaml"
+          },
+          {
+            name: "eo-chaos-network-loss",
+            chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-network-loss.yaml"
+          },
+          {
+            name: "eo-chaos-network-corrupt",
+            chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-network-corrupt.yaml"
+          },
+          {
+            name: "eo-chaos-network-bandwidth",
+            chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-network-bandwidth.yaml"
+          },
+          {
+            name: "eo-chaos-network-partition",
+            chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-network-partition.yaml"
+          },
+          {
+            name: "eo-chaos-stress-cpu",
+            chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-stress-cpu.yaml"
+          },
+          {
+            name: "eo-chaos-stress-memory",
+            chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-stress-memory.yaml"
+          },
+          {
+            name: "eo-chaos-mix",
+            chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-mix-chaos.yaml"
+          },
         ]
 
     steps:

--- a/deploy/chaos-mesh/chaos-mesh-exactly-pod-chaos.yaml
+++ b/deploy/chaos-mesh/chaos-mesh-exactly-pod-chaos.yaml
@@ -1,0 +1,26 @@
+# https://chaos-mesh.dev/reference/release-2.1/
+# https://chaos-mesh.org/docs/
+apiVersion: chaos-mesh.org/v1alpha1
+kind: Workflow
+metadata:
+  name: asp-platform
+spec:
+  entry: entry
+  templates:
+    - name: entry
+      templateType: Serial
+      children:
+        - pod-kill
+    - name: pod-kill
+      deadline: 10s
+      templateType: PodChaos
+      podChaos:
+        action: pod-kill
+        gracePeriod: 3
+        mode: one
+        selector:
+          namespaces:
+            - pulsar-cluster
+          labelSelectors:
+            cluster: pulsar-asp
+            component: broker

--- a/deploy/chart/asp-platform/asp-values.yaml
+++ b/deploy/chart/asp-platform/asp-values.yaml
@@ -1302,6 +1302,8 @@ broker:
     PULSAR_PREFIX_offsetsTopicNumPartitions: "8"
     PULSAR_PREFIX_kafkaTxnLogTopicNumPartitions: "8"
     PULSAR_PREFIX_kafkaTxnProducerStateTopicNumPartitions: "1"
+    PULSAR_PREFIX_kafkaTransactionProducerIdsStoredOnPulsar: "true"
+    PULSAR_PREFIX_kafkaTransactionCoordinatorEnabled: "true"
     brokerDeleteInactiveTopicsEnabled: "false"
     brokerDeduplicationEnabled: "true"
   ### Broker service account

--- a/deploy/chart/asp-platform/asp-values.yaml
+++ b/deploy/chart/asp-platform/asp-values.yaml
@@ -1302,8 +1302,8 @@ broker:
     PULSAR_PREFIX_offsetsTopicNumPartitions: "8"
     PULSAR_PREFIX_kafkaTxnLogTopicNumPartitions: "8"
     PULSAR_PREFIX_kafkaTxnProducerStateTopicNumPartitions: "1"
-    PULSAR_PREFIX_kafkaTransactionProducerIdsStoredOnPulsar: "true"
-    PULSAR_PREFIX_kafkaTransactionCoordinatorEnabled: "true"
+#    PULSAR_PREFIX_kafkaTransactionProducerIdsStoredOnPulsar: "true"
+#    PULSAR_PREFIX_kafkaTransactionCoordinatorEnabled: "true"
     brokerDeleteInactiveTopicsEnabled: "false"
     brokerDeduplicationEnabled: "true"
   ### Broker service account

--- a/scripts/asp-deploy.sh
+++ b/scripts/asp-deploy.sh
@@ -24,7 +24,7 @@ check_pod_status() {
         exit 1
     fi
     count=0
-    max_checks=60
+    max_checks=120
     interval=5
     while true; do
         echo "check pod status"

--- a/scripts/run-chao-test.sh
+++ b/scripts/run-chao-test.sh
@@ -6,7 +6,7 @@ app_root_path=${APP_ROOT_PATH:-"/app/chao-test-1.0-SNAPSHOT"}
 kafka_bootstrap_servers=${KAFKA_BOOTSTRAP_SERVERS:-"pulsar-asp-broker-headless:9092"}
 send_msg_count=${SEND_MSG_COUNT:-"50000"}
 max_waiting_time=${MAX_WAITING_TIME:-"600"}
-topic=${TOPIC:-"at-least-once"}
+topic_name=${TOPIC:-"at-least-once"}
 topic_partition=${TOPIC_PARTITION:-"10"}
 main_class=${MAIN_CLASS:-"com.ascentsream.tests.kop.AtLeastOnceMessaging"}
 
@@ -18,7 +18,7 @@ spec='
         "name": "chao-test",
         "image": "chao-test:latest",
         "imagePullPolicy": "Never",
-        "command": ["/bin/sh", "-c", "cd {{app_root_path}}/bin && exec sh runserver.sh -Dkafka.bootstrap.servers={{kafka_bootstrap_servers}} -Dsend.msg.count={{send_msg_count}} -Dtopic={{topic}} -Dkafka.group.id=group-1 -Dmax.waiting.time={{max_waiting_time}} -Dtopic.partition={{topic_partition}} {{main_class}}"],
+        "command": ["/bin/sh", "-c", "cd {{app_root_path}}/bin && exec sh runserver.sh -Dkafka.bootstrap.servers={{kafka_bootstrap_servers}} -Dsend.msg.count={{send_msg_count}} -Dtopic={{topic_name}} -Dkafka.group.id=group-1 -Dmax.waiting.time={{max_waiting_time}} -Dtopic.partition={{topic_partition}} {{main_class}}"],
        "volumeMounts": [
           {
             "name": "host-path",
@@ -53,6 +53,7 @@ spec=$(replace_string "$spec" "{{send_msg_count}}" "$send_msg_count")
 spec=$(replace_string "$spec" "{{max_waiting_time}}" "$max_waiting_time")
 spec=$(replace_string "$spec" "{{topic_partition}}" "$topic_partition")
 spec=$(replace_string "$spec" "{{main_class}}" "$main_class")
+spec=$(replace_string "$spec" "{{topic_name}}" "$topic_name")
 
 echo "$spec"
 kubectl -n ${ASP_NAMESPACE} run chao-test --image=chao-test:latest --restart=Never --overrides="$spec"

--- a/scripts/run-chao-test.sh
+++ b/scripts/run-chao-test.sh
@@ -6,8 +6,10 @@ app_root_path=${APP_ROOT_PATH:-"/app/chao-test-1.0-SNAPSHOT"}
 kafka_bootstrap_servers=${KAFKA_BOOTSTRAP_SERVERS:-"pulsar-asp-broker-headless:9092"}
 send_msg_count=${SEND_MSG_COUNT:-"50000"}
 max_waiting_time=${MAX_WAITING_TIME:-"600"}
+topic=${TOPIC:-"at-least-once"}
 topic_partition=${TOPIC_PARTITION:-"10"}
 main_class=${MAIN_CLASS:-"com.ascentsream.tests.kop.AtLeastOnceMessaging"}
+
 spec='
 {
   "spec": {
@@ -16,7 +18,7 @@ spec='
         "name": "chao-test",
         "image": "chao-test:latest",
         "imagePullPolicy": "Never",
-        "command": ["/bin/sh", "-c", "cd {{app_root_path}}/bin && exec sh runserver.sh -Dkafka.bootstrap.servers={{kafka_bootstrap_servers}} -Dsend.msg.count={{send_msg_count}} -Dtopic=at-least-once -Dkafka.group.id=group-1 -Dmax.waiting.time={{max_waiting_time}} -Dtopic.partition={{topic_partition}} {{main_class}}"],
+        "command": ["/bin/sh", "-c", "cd {{app_root_path}}/bin && exec sh runserver.sh -Dkafka.bootstrap.servers={{kafka_bootstrap_servers}} -Dsend.msg.count={{send_msg_count}} -Dtopic={{topic}} -Dkafka.group.id=group-1 -Dmax.waiting.time={{max_waiting_time}} -Dtopic.partition={{topic_partition}} {{main_class}}"],
        "volumeMounts": [
           {
             "name": "host-path",

--- a/src/main/java/com/ascentsream/tests/kop/ExactlyOnceMessaging.java
+++ b/src/main/java/com/ascentsream/tests/kop/ExactlyOnceMessaging.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;

--- a/src/main/java/com/ascentsream/tests/kop/ExactlyOnceMessaging.java
+++ b/src/main/java/com/ascentsream/tests/kop/ExactlyOnceMessaging.java
@@ -138,11 +138,6 @@ public class ExactlyOnceMessaging {
         boolean checkProduceSuc = DataUtil.checkSendOffsetIncrement(producerOffsetFile);
         log.info("check whether the sent offset is increasing : {}" , checkProduceSuc);
         boolean checkSuc = DataUtil.checkExactlyConsumer(producerMessages, producerOffsetFile, consumerMsgFile);
-        Map<Integer, Long> consumerLagOffsets = new TreeMap<>();
-        AtomicLong offsetCount = new AtomicLong();
-        AtomicLong lagCount = new AtomicLong();
-        log.info("offsets by admin : all offset {} , partitions {}, lag {}", offsetCount.get(), consumerLagOffsets,
-                lagCount);
         log.info("chao test result : {}.", checkSuc);
         consumerTask.close();
         try {

--- a/src/main/java/com/ascentsream/tests/kop/ExactlyOnceMessaging.java
+++ b/src/main/java/com/ascentsream/tests/kop/ExactlyOnceMessaging.java
@@ -20,10 +20,12 @@ import com.ascentsream.tests.kop.common.DataUtil;
 import com.ascentsream.tests.kop.common.KafkaClientUtils;
 import com.ascentsream.tests.kop.common.PulsarClientUtils;
 import com.ascentsream.tests.kop.task.ConsumerTask;
-import com.ascentsream.tests.kop.task.ProducerTask;
+import com.ascentsream.tests.kop.task.ProducerTransactionTask;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -41,58 +43,66 @@ import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class AtLeastOnceMessaging {
-    private static final Logger log = LoggerFactory.getLogger(AtLeastOnceMessaging.class);
+public class ExactlyOnceMessaging {
+    private static final Logger log = LoggerFactory.getLogger(ExactlyOnceMessaging.class);
 
     public static void main(String[] args) throws ExecutionException, InterruptedException, IOException {
         long startTime = System.currentTimeMillis();
-        String originMsgFile = DATA_ROOT_PATH + "/chao_test/origin/" + "messaging-key.csv";
-        String consumerMsgFile = DATA_ROOT_PATH+ "/chao_test/at-least-once/consumer/" + "revive-messaging.csv";
-        String producerOffsetFile = DATA_ROOT_PATH + "/chao_test/at-least-once/producer/" + "offset.csv";
+        String originMsgFilePrefix = DATA_ROOT_PATH + "/chao_test/origin/";
+        String consumerMsgFile = DATA_ROOT_PATH+ "/chao_test/exactly-once/consumer/" + "revive-messaging.csv";
+        String producerOffsetFile = DATA_ROOT_PATH + "/chao_test/exactly-once/producer/" + "offset.csv";
         int msgCount = Integer.parseInt(System.getProperty("send.msg.count", "1000"));
         int partitionNum = Integer.parseInt(System.getProperty("topic.partition", "10"));
         String bootstrapServers = System.getProperty("kafka.bootstrap.servers", "127.0.0.1:9092");
         String pulsarWebUrl = System.getProperty("pulsar.web.url", "http://pulsar-asp-proxy-headless:8080");
-        String topic = System.getProperty("topic", "at-least-once");
+        String topicStr = System.getProperty("topic", "transaction-1,transaction-2");
         String group = System.getProperty("kafka.group.id", "group-1");
         long maxWaitingTime = Long.parseLong(System.getProperty("max.waiting.time", String.valueOf(10 * 60 )));
 
-        BlockingQueue<String> receiveQueue = new LinkedBlockingQueue<>(msgCount * 2);
-        BlockingQueue<String> sendQueue = new LinkedBlockingQueue<>(msgCount * 2);
-        DataUtil.createTestData(originMsgFile, "key",  partitionNum, msgCount);
-        List<String> producerMessages = DataUtil.readToListFromFile(originMsgFile, true);
+        Map<String, List<String>> producerMessages = new HashMap<>();
         AdminClient kafkaAdmin = KafkaClientUtils.createKafkaAdmin(bootstrapServers);
-
-        if (kafkaAdmin.listTopics().names().get().contains(topic)) {
-            kafkaAdmin.deleteTopics(Collections.singleton(topic)).all().get();
-            Thread.sleep(3000);
-        }
-        NewTopic newTopic = new NewTopic(topic, partitionNum, (short) 2);
-        Map<String, String> topicConfig = new HashMap<>();
-        topicConfig.put(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(10 * 60 * 1000L));
-        newTopic.configs(topicConfig);
+        String[] topics = topicStr.split(",");
+        BlockingQueue<String> receiveQueue = new LinkedBlockingQueue<>(msgCount * topics.length * 2);
+        BlockingQueue<String> sendQueue = new LinkedBlockingQueue<>(msgCount * topics.length * 2);
         PulsarAdmin pulsarAdmin = PulsarClientUtils.createPulsarAdmin(pulsarWebUrl);
-//        kafkaAdmin.createTopics(
-//                Collections.singleton(new NewTopic(topic, partitionNum, (short) 2))).all().get();
-        try {
-            pulsarAdmin.topics().createPartitionedTopic(topic, partitionNum);
-            pulsarAdmin.topicPolicies().setRetention(topic, new RetentionPolicies(-1, -1));
-        } catch (Exception e) {
-            log.error("createPartitionedTopic error : ", e);
+        int startValue =0 ;
+        for (int i = 0; i < topics.length; i++) {
+            String topic = topics[i];
+            if (kafkaAdmin.listTopics().names().get().contains(topic)) {
+                kafkaAdmin.deleteTopics(Collections.singleton(topic)).all().get();
+                Thread.sleep(3000);
+            }
+            NewTopic newTopic = new NewTopic(topic, partitionNum, (short) 2);
+            Map<String, String> topicConfig = new HashMap<>();
+            topicConfig.put(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(10 * 60 * 1000L));
+            newTopic.configs(topicConfig);
+            try {
+                pulsarAdmin.topics().createPartitionedTopic(topic, partitionNum);
+                pulsarAdmin.topicPolicies().setRetention(topic, new RetentionPolicies(-1, -1));
+            } catch (Exception e) {
+                log.error("createPartitionedTopic error : ", e);
+            }
+            String originMsgFile = originMsgFilePrefix + "messaging-key-" + i + ".csv";
+            DataUtil.createTestData(originMsgFile, "transaction" + i, partitionNum, msgCount, startValue);
+            producerMessages.put(topic, DataUtil.readToListFromFile(originMsgFile, true));
+            startValue = msgCount;
         }
-
+        int msgTotalNum = 0;
+        for (String topic : topics ) {
+            msgTotalNum += producerMessages.get(topic).size();
+        }
         AtomicInteger sendCount = new AtomicInteger();
         AtomicInteger consumedCount = new AtomicInteger();
-        ConsumerTask consumerTask = new ConsumerTask(bootstrapServers, Collections.singleton(topic), group,
-                partitionNum, producerMessages.size(), consumedCount, receiveQueue, false);
-        KafkaProducer<String, Integer> producer = getKafkaProducer(bootstrapServers);
-        ProducerTask producerTask = new ProducerTask(producer, topic, producerMessages, producerOffsetFile,
-                sendCount, sendQueue);
+        ConsumerTask consumerTask = new ConsumerTask(bootstrapServers,
+                new HashSet<>(Arrays.asList(topics)), group, partitionNum, msgTotalNum, consumedCount, receiveQueue,
+                true);
+        KafkaProducer<String, Integer> producer = getKafkaProducer(bootstrapServers, "id-" + System.currentTimeMillis());
+        ProducerTransactionTask producerTask = new ProducerTransactionTask(producer, topics, producerMessages,
+                producerOffsetFile, sendCount, sendQueue);
         Thread.sleep(5000);
         producerTask.start();
         consumerTask.start();
         Thread.sleep(5000);
-
         ConsumerGroupsCli consumerGroupsCli = new ConsumerGroupsCli(kafkaAdmin);
         while (true) {
             long waitingTime = (System.currentTimeMillis() - startTime);
@@ -106,7 +116,7 @@ public class AtLeastOnceMessaging {
             try {
                 AtomicLong lagCount = new AtomicLong();
                 KafkaClientUtils.printGroupLag(consumerGroupsCli, group, lagCount);
-                if (lagCount.get() == 0L && consumedCount.get() >= producerMessages.size() && producerTask.isDone()) {
+                if (lagCount.get() == 0L && consumedCount.get() >= msgTotalNum && producerTask.isDone()) {
                     Thread.sleep(10000);
                     break;
                 }
@@ -118,27 +128,28 @@ public class AtLeastOnceMessaging {
         log.info("group[{}] received msg count {} ", group, consumedCount.get());
 
         DataUtil.writeQueueToFile(receiveQueue, consumerMsgFile, "partition,offset,key,value,topic");
-        log.info("\n*************At least once test end *************\n");
+
+        log.info("\n*************exactly once test end *************\n");
         log.info("*************results analysis*************");
-        log.info("number of original messages : {}", DataUtil.getTotalLines(originMsgFile));
+        log.info("number of original messages : {}", msgTotalNum);
         log.info("number of successfully sent messages : {}", DataUtil.getTotalLines(producerOffsetFile));
         log.info("number of successful consumption : {}", DataUtil.getTotalLines(consumerMsgFile));
 
         boolean checkProduceSuc = DataUtil.checkSendOffsetIncrement(producerOffsetFile);
         log.info("check whether the sent offset is increasing : {}" , checkProduceSuc);
-
-        boolean checkSuc = DataUtil.checkDataNotLoss(originMsgFile, producerOffsetFile, consumerMsgFile);
+        boolean checkSuc = DataUtil.checkExactlyConsumer(producerMessages, producerOffsetFile, consumerMsgFile);
         Map<Integer, Long> consumerLagOffsets = new TreeMap<>();
         AtomicLong offsetCount = new AtomicLong();
         AtomicLong lagCount = new AtomicLong();
+        log.info("offsets by admin : all offset {} , partitions {}, lag {}", offsetCount.get(), consumerLagOffsets,
+                lagCount);
         log.info("chao test result : {}.", checkSuc);
         consumerTask.close();
         try {
-            KafkaClientUtils.printGroupLag(consumerGroupsCli, group, lagCount, consumerLagOffsets, offsetCount);
-            log.info("offsets by admin : all offset {} , partitions {}, lag {}", offsetCount.get(), consumerLagOffsets,
-                    lagCount);
-            PulsarClientUtils.printInternalStats(pulsarAdmin, topic);
-            kafkaAdmin.deleteTopics(Collections.singleton(topic)).all();
+            for (String topic : topics ) {
+                PulsarClientUtils.printInternalStats(pulsarAdmin, topic);
+                kafkaAdmin.deleteTopics(Collections.singleton(topic)).all();
+            }
             kafkaAdmin.close();
             pulsarAdmin.close();
         } catch (Exception e) {

--- a/src/main/java/com/ascentsream/tests/kop/common/DataUtil.java
+++ b/src/main/java/com/ascentsream/tests/kop/common/DataUtil.java
@@ -186,11 +186,10 @@ public class DataUtil {
     }
 
     /**
-     * Check if data is lost.
+     * check Exactly Consumer.
      *
-     * @param producerMessages [key , value ]
-     *      key_8,999
-     *      key_9,1000
+     * @param producerMessages
+     *
      * @param producerOffsetFile [partition, offset]
      *      0,1
      *      0,2
@@ -266,7 +265,7 @@ public class DataUtil {
     }
 
     /**
-     * check producer send offset increment .
+     * check producer send offset sequence .
      *
      * @param producerOffsetFile .
      * @return boolean

--- a/src/main/java/com/ascentsream/tests/kop/common/DataUtil.java
+++ b/src/main/java/com/ascentsream/tests/kop/common/DataUtil.java
@@ -215,7 +215,11 @@ public class DataUtil {
         consumerMessages.forEach(str -> {
             String[] array = str.split(",");
             int value = Integer.parseInt(array[3]);
+            if (consumerMsgs.contains(value)) {
+                log.warn("Repeating messages {}", str);
+            }
             consumerMsgs.add(value);
+
         });
 
         boolean ret = producerMsgs.size() == originMessages.size() && consumerMsgs.containsAll(producerMsgs)

--- a/src/main/java/com/ascentsream/tests/kop/common/DataUtil.java
+++ b/src/main/java/com/ascentsream/tests/kop/common/DataUtil.java
@@ -47,7 +47,12 @@ public class DataUtil {
      * @param msgCount the total number of messages.
      *
      */
-    public static void createTestData(String fileName, int keyNum, int msgCount) throws IOException {
+    public static void createTestData(String fileName, String keyPrefix, int keyNum, int msgCount) throws IOException {
+        createTestData(fileName, keyPrefix, keyNum, msgCount, 0);
+    }
+
+    public static void createTestData(String fileName, String keyPrefix, int keyNum, int msgCount, int startValue)
+            throws IOException {
         Path pathToFile = Paths.get(fileName);
         if (!Files.exists(pathToFile)) {
             Files.createDirectories(pathToFile.getParent());
@@ -60,8 +65,8 @@ public class DataUtil {
             if (keyNum <= 0) {
                 throw new RuntimeException( "keyNum must > 0!");
             }
-            key = "key_" + (i % (keyNum * 3));
-            writer.write(key + "," + String.valueOf(i + 1));
+            key = keyPrefix + "_" + (i % (keyNum * 3));
+            writer.write(key + "," + String.valueOf(startValue + i + 1));
             writer.newLine();
         }
         writer.flush();
@@ -181,6 +186,49 @@ public class DataUtil {
     }
 
     /**
+     * Check if data is lost.
+     *
+     * @param producerMessages [key , value ]
+     *      key_8,999
+     *      key_9,1000
+     * @param producerOffsetFile [partition, offset]
+     *      0,1
+     *      0,2
+     * @param consumerMsgFile [partition, offset, key , value]
+     *      0,1,key_8,999
+     *      0,2,key_9,1000
+     * @return boolean
+     *
+     */
+    public static boolean checkExactlyConsumer(Map<String, List<String>> producerMessages, String producerOffsetFile,
+                                               String consumerMsgFile) throws IOException {
+
+        List<String> originMessages = new ArrayList<>();
+        producerMessages.values().forEach(producerMessage -> originMessages.addAll(producerMessage));
+        List<String> consumerMessages = readToListFromFile(consumerMsgFile, true);
+
+        List<Integer> producerMsgs = new ArrayList<>();
+        List<Integer> consumerMsgs = new ArrayList<>();
+
+
+        originMessages.forEach(str -> producerMsgs.add(Integer.valueOf(str.split(",")[1])));
+        consumerMessages.forEach(str -> {
+            String[] array = str.split(",");
+            int value = Integer.parseInt(array[3]);
+            consumerMsgs.add(value);
+        });
+
+        boolean ret = producerMsgs.size() == originMessages.size() && consumerMsgs.containsAll(producerMsgs)
+                && producerMsgs.containsAll(consumerMsgs);
+        log.info("number of original data : {}", producerMsgs.size());
+        producerMsgs.removeAll(consumerMsgs);
+        log.info("number of receive data : {}", consumerMsgs.size());
+        log.info("number of loss data num: {}", producerMsgs.size());
+        log.info("number of loss data : {}", producerMsgs);
+        return ret;
+    }
+
+    /**
      * check producer send offset increment .
      *
      * @param producerOffsetFile .
@@ -193,18 +241,20 @@ public class DataUtil {
         for (String offsetStr : producerOffsets) {
             String[] arrays = offsetStr.split(",");
             String partition = arrays[0];
-            int value = Integer.valueOf(arrays[1]);
-            if (!offsets.containsKey(partition)) {
-                offsets.put(partition, new PriorityQueue<>(Comparator.reverseOrder()));
-                offsets.get(partition).add(value);
+            int offset = Integer.valueOf(arrays[1]);
+            String topic = arrays[3];
+            String key = topic + "-" + partition;
+            if (!offsets.containsKey(key)) {
+                offsets.put(key, new PriorityQueue<>(Comparator.reverseOrder()));
+                offsets.get(key).add(offset);
             } else {
-                int max = offsets.get(partition).peek();
-                if (value <= max) {
-                    log.info("producerOffsetFile {} partition {} not increment, current {}, pre {}",
-                            producerOffsetFile, partition, value, max);
+                int max = offsets.get(key).peek();
+                if (offset <= max) {
+                    log.info("producerOffsetFile {} topic {} partition {} not increment, current {}, pre {}",
+                            producerOffsetFile, topic, partition, offset, max);
                     return false;
                 } else {
-                    offsets.get(partition).add(value);
+                    offsets.get(key).add(offset);
                 }
             }
         }
@@ -224,18 +274,20 @@ public class DataUtil {
         for (String offsetStr : producerOffsets) {
             String[] arrays = offsetStr.split(",");
             String partition = arrays[0];
-            int value = Integer.valueOf(arrays[1]);
-            if (!offsets.containsKey(partition)) {
-                offsets.put(partition, new PriorityQueue<>(Comparator.reverseOrder()));
-                offsets.get(partition).add(value);
+            int offset = Integer.valueOf(arrays[1]);
+            String topic = arrays[3];
+            String key = topic + "-" + partition;
+            if (!offsets.containsKey(key)) {
+                offsets.put(key, new PriorityQueue<>(Comparator.reverseOrder()));
+                offsets.get(key).add(offset);
             } else {
-                int max = offsets.get(partition).peek();
-                if (value != max + 1) {
-                    log.info("producerOffsetFile {} partition {} not sequence, current {}, pre {}",
-                            producerOffsetFile, partition, value, max);
+                int max = offsets.get(key).peek();
+                if (offset != max + 1) {
+                    log.info("producerOffsetFile {} topic {} partition {} not sequence, current {}, pre {}",
+                            producerOffsetFile, topic, partition, offset, max);
                     return false;
                 } else {
-                    offsets.get(partition).add(value);
+                    offsets.get(topic).add(offset);
                 }
             }
         }

--- a/src/main/java/com/ascentsream/tests/kop/common/DataUtil.java
+++ b/src/main/java/com/ascentsream/tests/kop/common/DataUtil.java
@@ -287,7 +287,7 @@ public class DataUtil {
                             producerOffsetFile, topic, partition, offset, max);
                     return false;
                 } else {
-                    offsets.get(topic).add(offset);
+                    offsets.get(key).add(offset);
                 }
             }
         }

--- a/src/main/java/com/ascentsream/tests/kop/task/ConsumerTask.java
+++ b/src/main/java/com/ascentsream/tests/kop/task/ConsumerTask.java
@@ -17,6 +17,7 @@ import static com.ascentsream.tests.kop.common.KafkaClientUtils.getKafkaConsumer
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Data;
@@ -34,18 +35,19 @@ public class ConsumerTask {
     private final AtomicInteger consumedCount;
 
     public ConsumerTask(String bootstrapServers,
-                        String topic,
+                        Set<String> topic,
                         String group,
                         int consumerNum,
                         int msgTotalNum,
                         AtomicInteger consumedCount,
-                        BlockingQueue<String> receiveQueue) {
+                        BlockingQueue<String> receiveQueue,
+                        boolean isTransaction) {
         this.msgTotalNum = msgTotalNum;
         this.consumedCount = consumedCount;
         this.receiveQueue = receiveQueue;
         for (int i = 0; i < consumerNum; i++) {
-            KafkaConsumer<String, Integer> consumer = getKafkaConsumer(bootstrapServers, group);
-            consumer.subscribe(Collections.singleton(topic));
+            KafkaConsumer<String, Integer> consumer = getKafkaConsumer(bootstrapServers, group, isTransaction);
+            consumer.subscribe(topic);
             consumers.add(consumer);
         }
     }

--- a/src/main/java/com/ascentsream/tests/kop/task/ConsumerThread.java
+++ b/src/main/java/com/ascentsream/tests/kop/task/ConsumerThread.java
@@ -43,11 +43,10 @@ public class ConsumerThread extends Thread {
         while (running) {
             try {
                 ConsumerRecords<String, Integer> records = consumer.poll(Duration.ofMillis(1000));
-
                 for (ConsumerRecord<String, Integer> record : records) {
                     consumerTask.getConsumedCount().incrementAndGet();
                     consumerTask.getReceiveQueue().add(record.partition() + "," + record.offset() + "," + record.key()
-                            + "," + record.value());
+                            + "," + record.value()  + "," + record.topic());
                 }
                 if (consumerTask.getConsumedCount().get() >= consumerTask.getMsgTotalNum()) {
                     Map<TopicPartition, Long> partitionLag = getPartitionLag(consumer, consumer.assignment());

--- a/src/main/java/com/ascentsream/tests/kop/task/ProducerTransactionTask.java
+++ b/src/main/java/com/ascentsream/tests/kop/task/ProducerTransactionTask.java
@@ -11,11 +11,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Data;
-import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.common.errors.ProducerFencedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/ascentsream/tests/kop/task/ProducerTransactionTask.java
+++ b/src/main/java/com/ascentsream/tests/kop/task/ProducerTransactionTask.java
@@ -1,0 +1,123 @@
+package com.ascentsream.tests.kop.task;
+
+import com.ascentsream.tests.kop.common.DataUtil;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Data;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Data
+public class ProducerTransactionTask {
+    private static final Logger log = LoggerFactory.getLogger(ProducerTransactionTask.class);
+    private KafkaProducer<String, Integer> producer;
+    private final Map<String, List<String>> producerMessages;
+    private final String[] topics;
+    private final BlockingQueue<String> sendQueue;
+    private final AtomicInteger sendCount;
+    private final String producerOffsetFile;
+    private volatile boolean isDone = false;
+
+    public ProducerTransactionTask(KafkaProducer<String, Integer> producer, String[] topics,
+                                   Map<String, List<String>> producerMessages,
+                                   String producerOffsetFile,
+                                   AtomicInteger sendCount,
+                                   BlockingQueue<String> sendQueue) throws IOException {
+        this.producerMessages = producerMessages;
+        this.producerOffsetFile = producerOffsetFile;
+        this.sendCount = sendCount;
+        this.sendQueue = sendQueue;
+        this.topics = topics;
+        this.producer = producer;
+    }
+
+    public void start() {
+        AtomicInteger sendFailedCount = new AtomicInteger();
+        producer.initTransactions();
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                int oneTopicSendNum = producerMessages.get(topics[0]).size();
+                for (int i = 0; i < oneTopicSendNum; i++) {
+                    try {
+                        producer.beginTransaction();
+                        List<Future<RecordMetadata>> futures = new ArrayList<>();
+                        Map<String , Integer> values = new HashMap<>();
+                        for (String topic : topics) {
+                            String msgStr = producerMessages.get(topic).get(i);
+                            String[] objMsg = msgStr.split(",");
+                            String key = null;
+                            int value = -1;
+                            if (objMsg.length > 1) {
+                                key = objMsg[0];
+                                value = Integer.valueOf(objMsg[1]);
+                            } else {
+                                value = Integer.valueOf(objMsg[0]);
+                            }
+                            int finalValue = value;
+                            values.put(topic, finalValue);
+                            Future<RecordMetadata> future =
+                                    producer.send(new ProducerRecord<String, Integer>(topic, key, finalValue));
+                            futures.add(future);
+                        }
+                        List<RecordMetadata> recordMetadatas = new ArrayList<>();
+                        for (Future<RecordMetadata> future : futures) {
+                            recordMetadatas.add(future.get(10, TimeUnit.SECONDS));
+                        }
+                        producer.commitTransaction();
+                        recordMetadatas.forEach(metadata -> {
+                            sendCount.incrementAndGet();
+                            sendQueue.add(
+                                    metadata.partition() + "," + metadata.offset() + ","
+                                            + values.get(metadata.topic()) + "," + metadata.topic());
+                        });
+                    } catch (Exception e) {
+                        try {
+                            producer.abortTransaction();
+                        } catch (Exception ex) {
+                            log.error("ProducerFencedException, ", ex);
+                        }
+                        --i;
+                        log.error("abort transaction : ", e);
+                    }
+                }
+            }
+        }).start();
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                int oneTopicSendNum = producerMessages.get(topics[0]).size();
+                int sendAllNum = oneTopicSendNum * topics.length;
+                while ((sendCount.get() + sendFailedCount.get()) < sendAllNum && !isDone) {
+                    try {
+                        log.info("sending msg : suc {}, failed {}, total {}.",
+                                sendCount.get(), sendFailedCount.get(), sendAllNum);
+                        Thread.sleep(3000);
+                    } catch (InterruptedException e) {
+                        log.error("InterruptedException ", e);
+                    }
+                }
+                isDone = true;
+                log.info("sent msg : suc {}, failed {}, total {}.", sendCount.get(), sendFailedCount.get(), sendAllNum);
+                try {
+                    DataUtil.writeQueueToFile(sendQueue, producerOffsetFile, "partition,offset,value,topic" );
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+                producer.close();
+            }
+        }).start();
+    }
+}

--- a/src/main/java/com/ascentsream/tests/kop/task/ProducerTransactionTask.java
+++ b/src/main/java/com/ascentsream/tests/kop/task/ProducerTransactionTask.java
@@ -69,7 +69,7 @@ public class ProducerTransactionTask {
                             int finalValue = value;
                             values.put(topic, finalValue);
                             Future<RecordMetadata> future =
-                                    producer.send(new ProducerRecord<String, Integer>(topic, key, finalValue));
+                                    producer.send(new ProducerRecord<String, Integer>(topic, finalValue));
                             futures.add(future);
                         }
                         List<RecordMetadata> recordMetadatas = new ArrayList<>();

--- a/src/main/java/com/ascentsream/tests/kop/task/ProducerTransactionTask.java
+++ b/src/main/java/com/ascentsream/tests/kop/task/ProducerTransactionTask.java
@@ -91,6 +91,14 @@ public class ProducerTransactionTask {
                         }
                         --i;
                         log.error("abort transaction : ", e);
+                        try {
+                            Thread.sleep(1000);
+                        } catch (InterruptedException ex) {
+                            throw new RuntimeException(ex);
+                        }
+                    }
+                    if (isDone) {
+                        break;
                     }
                 }
             }


### PR DESCRIPTION

### Motivation

add exactly once case
- enable transaction
- Send a fixed number of messages to two topics
- Consume all messages
- Compare the Value of Production and Consumption
- Inject network, pod kill and other failures


