### PR TITLE
feat: enable KoP on broker for chao-test cluster

### DIFF
--- a/.github/actions/run-chaos-test/action.yml
+++ b/.github/actions/run-chaos-test/action.yml
@@ -1,0 +1,62 @@
+name: 'Run chaos test'
+description: |
+  Shared workflow for chao-test matrix jobs: loads the pre-built docker
+  image, provisions a kind cluster, deploys the asp-platform and
+  chaos-mesh, runs the test, injects the configured fault, and waits
+  for the chaos-mesh workflow to finish.
+
+inputs:
+  test-name:
+    description: 'Matrix test name (used for human-readable step names)'
+    required: true
+  chaos-mesh-config:
+    description: 'Path to the chaos-mesh workflow YAML to apply'
+    required: true
+  repo-path:
+    description: 'Repository root on the runner ($REPO_PATH)'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Load chao-test image
+      run: docker load --input /tmp/chao-test.tar
+      shell: bash
+
+    - name: Create kind cluster
+      uses: helm/kind-action@v1.5.0
+      with:
+        cluster_name: kind
+        kubectl_version: v1.25.5
+
+    - name: Deploy asp-platform
+      run: ${{ inputs.repo-path }}/scripts/ci.sh deploy_as_platform
+      shell: bash
+
+    - name: Deploy chaos-mesh
+      run: |
+        curl -sSL https://mirrors.chaos-mesh.org/v2.7.0/install.sh | \
+          bash -s -- --local kind --kind-version v0.17.0 --name kind --k8s-version 1.25.3
+        kubectl get pod -n chaos-mesh
+      shell: bash
+
+    - name: Run chao-test (${{ inputs.test-name }})
+      run: |
+        kind load docker-image chao-test:latest
+        ${{ inputs.repo-path }}/scripts/run-chao-test.sh
+        kubectl -n pulsar-cluster get pods
+      shell: bash
+
+    - name: Inject chaos fault
+      run: |
+        sleep 30
+        kubectl -n chaos-mesh apply -f ${{ inputs.chaos-mesh-config }}
+        echo "chaos-mesh workflows:"
+        kubectl -n chaos-mesh get workflow
+        echo "chaos-mesh workflownodes:"
+        kubectl -n chaos-mesh get workflownode --selector="chaos-mesh.org/workflow=asp-platform"
+      shell: bash
+
+    - name: Wait for workflow completion
+      run: ${{ inputs.repo-path }}/scripts/wait-workflow-completion.sh
+      shell: bash

--- a/.github/workflows/kop-test-per-hour.yml
+++ b/.github/workflows/kop-test-per-hour.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout chao-test codebase
         uses: actions/checkout@v4
@@ -43,6 +44,7 @@ jobs:
   alo-chao:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       REPO_PATH: ${{ github.workspace }}
       RELEASE_BRANCH: main
@@ -135,6 +137,7 @@ jobs:
   idempotence-chao:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       REPO_PATH: ${{ github.workspace }}
       RELEASE_BRANCH: main
@@ -186,6 +189,7 @@ jobs:
   eo-chao:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       REPO_PATH: ${{ github.workspace }}
       AS_PLATFORM_IMAGE_TAG: chao-test-latest

--- a/.github/workflows/kop-test-per-hour.yml
+++ b/.github/workflows/kop-test-per-hour.yml
@@ -108,42 +108,18 @@ jobs:
 
     steps:
       - name: Checkout chao-test codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download chao-test image
         uses: actions/download-artifact@v4
         with:
           name: chao-test-image
           path: /tmp
-      - name: Load chao-test image
-        run: docker load --input /tmp/chao-test.tar
-
-      - uses: helm/kind-action@v1.5.0
+      - uses: ./.github/actions/run-chaos-test
         with:
-          cluster_name: kind
-          kubectl_version: v1.25.5
-
-      - name: deploy as-platform
-        run: ${{ env.REPO_PATH }}/scripts/ci.sh deploy_as_platform
-      - name: deploy chaos-mesh
-        run: |
-          curl -sSL https://mirrors.chaos-mesh.org/v2.7.0/install.sh | bash -s -- --local kind --kind-version v0.17.0 --name kind  --k8s-version  1.25.3
-          kubectl get pod  -n chaos-mesh
-      - name: ${{ matrix.test.name }}
-        run: |
-          kind load docker-image chao-test:latest
-          ${{ env.REPO_PATH }}/scripts/run-chao-test.sh
-          kubectl -n pulsar-cluster get pods
-      - name: injecting faults
-        run: |
-          sleep 30
-          kubectl -n chaos-mesh apply -f ${{ matrix.test.chaos-mesh-config }}
-          echo "get chaos-mesh workflow "
-          kubectl -n chaos-mesh get workflow
-          echo "get chaos-mesh workflownode "
-          kubectl -n chaos-mesh get workflownode --selector="chaos-mesh.org/workflow=asp-platform"
-      - name: Wait for workflow completion
-        run:  ${{ env.REPO_PATH }}/scripts/wait-workflow-completion.sh
+          test-name: ${{ matrix.test.name }}
+          chaos-mesh-config: ${{ matrix.test.chaos-mesh-config }}
+          repo-path: ${{ env.REPO_PATH }}
 
       - name: package reports
         if: failure()
@@ -184,42 +160,18 @@ jobs:
 
     steps:
       - name: Checkout chao-test codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download chao-test image
         uses: actions/download-artifact@v4
         with:
           name: chao-test-image
           path: /tmp
-      - name: Load chao-test image
-        run: docker load --input /tmp/chao-test.tar
-
-      - uses: helm/kind-action@v1.5.0
+      - uses: ./.github/actions/run-chaos-test
         with:
-          cluster_name: kind
-          kubectl_version: v1.25.5
-
-      - name: deploy as-platform
-        run: ${{ env.REPO_PATH }}/scripts/ci.sh deploy_as_platform
-      - name: deploy chaos-mesh
-        run: |
-          curl -sSL https://mirrors.chaos-mesh.org/v2.7.0/install.sh | bash -s -- --local kind --kind-version v0.17.0 --name kind  --k8s-version  1.25.3
-          kubectl get pod  -n chaos-mesh
-      - name: ${{ matrix.test.name }}
-        run: |
-          kind load docker-image chao-test:latest
-          ${{ env.REPO_PATH }}/scripts/run-chao-test.sh
-          kubectl -n pulsar-cluster get pods
-      - name: injecting faults
-        run: |
-          sleep 30
-          kubectl -n chaos-mesh apply -f ${{ matrix.test.chaos-mesh-config }}
-          echo "get chaos-mesh workflow "
-          kubectl -n chaos-mesh get workflow
-          echo "get chaos-mesh workflownode "
-          kubectl -n chaos-mesh get workflownode --selector="chaos-mesh.org/workflow=asp-platform"
-      - name: Wait for workflow completion
-        run: ${{ env.REPO_PATH }}/scripts/wait-workflow-completion.sh
+          test-name: ${{ matrix.test.name }}
+          chaos-mesh-config: ${{ matrix.test.chaos-mesh-config }}
+          repo-path: ${{ env.REPO_PATH }}
 
       - name: package reports
         if: failure()
@@ -291,42 +243,18 @@ jobs:
 
     steps:
       - name: Checkout chao-test codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download chao-test image
         uses: actions/download-artifact@v4
         with:
           name: chao-test-image
           path: /tmp
-      - name: Load chao-test image
-        run: docker load --input /tmp/chao-test.tar
-
-      - uses: helm/kind-action@v1.5.0
+      - uses: ./.github/actions/run-chaos-test
         with:
-          cluster_name: kind
-          kubectl_version: v1.25.5
-
-      - name: deploy as-platform
-        run: ${{ env.REPO_PATH }}/scripts/ci.sh deploy_as_platform
-      - name: deploy chaos-mesh
-        run: |
-          curl -sSL https://mirrors.chaos-mesh.org/v2.7.0/install.sh | bash -s -- --local kind --kind-version v0.17.0 --name kind  --k8s-version  1.25.3
-          kubectl get pod  -n chaos-mesh
-      - name: ${{ matrix.test.name }}
-        run: |
-          kind load docker-image chao-test:latest
-          ${{ env.REPO_PATH }}/scripts/run-chao-test.sh
-          kubectl -n pulsar-cluster get pods
-      - name: injecting faults
-        run: |
-          sleep 30
-          kubectl -n chaos-mesh apply -f ${{ matrix.test.chaos-mesh-config }}
-          echo "get chaos-mesh workflow "
-          kubectl -n chaos-mesh get workflow
-          echo "get chaos-mesh workflownode "
-          kubectl -n chaos-mesh get workflownode --selector="chaos-mesh.org/workflow=asp-platform"
-      - name: Wait for workflow completion
-        run: ${{ env.REPO_PATH }}/scripts/wait-workflow-completion.sh
+          test-name: ${{ matrix.test.name }}
+          chaos-mesh-config: ${{ matrix.test.chaos-mesh-config }}
+          repo-path: ${{ env.REPO_PATH }}
 
       - name: package reports
         if: failure()

--- a/.github/workflows/kop-test-per-hour.yml
+++ b/.github/workflows/kop-test-per-hour.yml
@@ -155,7 +155,7 @@ jobs:
           kubectl cp pulsar-cluster/pulsar-asp-broker-1:/pulsar/heap-pulsar-asp-broker-1.bin ${current_dir}/artifacts/pulsar/heap-pulsar-asp-broker-1.bin
           zip -r artifacts-${{ matrix.test.name }}.zip artifacts
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         name: upload reports
         if: failure()
         with:
@@ -260,7 +260,7 @@ jobs:
           kubectl cp pulsar-cluster/pulsar-asp-broker-1:/pulsar/heap-pulsar-asp-broker-1.bin ${current_dir}/artifacts/pulsar/heap-pulsar-asp-broker-1.bin
           zip -r artifacts-${{ matrix.test.name }}.zip artifacts
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         name: upload reports
         if: failure()
         with:
@@ -398,7 +398,7 @@ jobs:
           kubectl cp pulsar-cluster/pulsar-asp-broker-1:/pulsar/heap-pulsar-asp-broker-1.bin ${current_dir}/artifacts/pulsar/heap-pulsar-asp-broker-1.bin
           zip -r artifacts-${{ matrix.test.name }}.zip artifacts
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         name: upload reports
         if: failure()
         with:

--- a/.github/workflows/kop-test-per-hour.yml
+++ b/.github/workflows/kop-test-per-hour.yml
@@ -97,7 +97,7 @@ jobs:
           #            chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-io-fault.yaml"
           #          },
           {
-            name: "eo-chaos-stress",
+            name: "alo-chaos-stress",
             chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-stress.yaml"
           },
           {
@@ -117,11 +117,6 @@ jobs:
           path: /tmp
       - name: Load chao-test image
         run: docker load --input /tmp/chao-test.tar
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.ASCENTSTREAM_DOCKER_USERNAME }}
-          password: ${{ secrets.ASCENTSTREAM_DOCKER_PASSWORD }}
 
       - uses: helm/kind-action@v1.5.0
         with:
@@ -218,11 +213,6 @@ jobs:
           path: /tmp
       - name: Load chao-test image
         run: docker load --input /tmp/chao-test.tar
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.ASCENTSTREAM_DOCKER_USERNAME }}
-          password: ${{ secrets.ASCENTSTREAM_DOCKER_PASSWORD }}
 
       - uses: helm/kind-action@v1.5.0
         with:
@@ -350,11 +340,6 @@ jobs:
           path: /tmp
       - name: Load chao-test image
         run: docker load --input /tmp/chao-test.tar
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.ASCENTSTREAM_DOCKER_USERNAME }}
-          password: ${{ secrets.ASCENTSTREAM_DOCKER_PASSWORD }}
 
       - uses: helm/kind-action@v1.5.0
         with:

--- a/.github/workflows/kop-test-per-hour.yml
+++ b/.github/workflows/kop-test-per-hour.yml
@@ -30,12 +30,9 @@ jobs:
       - name: Build jar
         run: mvn clean package
       - name: Build docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: false
-          tags: chao-test:latest
-          outputs: type=docker,dest=/tmp/chao-test.tar
+        run: |
+          docker build -t chao-test:latest .
+          docker save chao-test:latest -o /tmp/chao-test.tar
       - name: Upload docker image
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/kop-test-per-hour.yml
+++ b/.github/workflows/kop-test-per-hour.yml
@@ -17,7 +17,34 @@ env:
   GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout chao-test codebase
+        uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+      - name: Build jar
+        run: mvn clean package
+      - name: Build docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          tags: chao-test:latest
+          outputs: type=docker,dest=/tmp/chao-test.tar
+      - name: Upload docker image
+        uses: actions/upload-artifact@v4
+        with:
+          name: chao-test-image
+          path: /tmp/chao-test.tar
+          retention-days: 1
+
   alo-chao:
+    needs: build
     runs-on: ubuntu-latest
     env:
       REPO_PATH: ${{ github.workspace }}
@@ -86,18 +113,13 @@ jobs:
       - name: Checkout chao-test codebase
         uses: actions/checkout@v3
 
-      - uses: actions/setup-java@v3
+      - name: Download chao-test image
+        uses: actions/download-artifact@v4
         with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
-      - name: Build
-        run: mvn clean package
-      - name: Build docker
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: false
-          tags: chao-test:latest
+          name: chao-test-image
+          path: /tmp
+      - name: Load chao-test image
+        run: docker load --input /tmp/chao-test.tar
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -163,6 +185,7 @@ jobs:
           path: artifacts-${{ matrix.test.name }}.zip
 
   idempotence-chao:
+    needs: build
     runs-on: ubuntu-latest
     env:
       REPO_PATH: ${{ github.workspace }}
@@ -191,18 +214,13 @@ jobs:
       - name: Checkout chao-test codebase
         uses: actions/checkout@v3
 
-      - uses: actions/setup-java@v3
+      - name: Download chao-test image
+        uses: actions/download-artifact@v4
         with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
-      - name: Build
-        run: mvn clean package
-      - name: Build docker
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: false
-          tags: chao-test:latest
+          name: chao-test-image
+          path: /tmp
+      - name: Load chao-test image
+        run: docker load --input /tmp/chao-test.tar
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -267,10 +285,9 @@ jobs:
           name: artifacts-${{ matrix.test.name }}
           path: artifacts-${{ matrix.test.name }}.zip
   eo-chao:
+    needs: build
     runs-on: ubuntu-latest
     env:
-      JAVA_VERSION: 17
-      JAVA_DISTRIBUTION: temurin
       REPO_PATH: ${{ github.workspace }}
       AS_PLATFORM_IMAGE_TAG: chao-test-latest
       REGISTRY_USERNAME: ${{ secrets.ASCENTSTREAM_DOCKER_USERNAME }}
@@ -329,18 +346,13 @@ jobs:
       - name: Checkout chao-test codebase
         uses: actions/checkout@v3
 
-      - uses: actions/setup-java@v3
+      - name: Download chao-test image
+        uses: actions/download-artifact@v4
         with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
-      - name: Build
-        run: mvn clean package
-      - name: Build docker
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: false
-          tags: chao-test:latest
+          name: chao-test-image
+          path: /tmp
+      - name: Load chao-test image
+        run: docker load --input /tmp/chao-test.tar
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/kop-test-per-hour.yml
+++ b/.github/workflows/kop-test-per-hour.yml
@@ -147,27 +147,7 @@ jobs:
 
       - name: package reports
         if: failure()
-        run: |
-          rm -rf artifacts
-          mkdir artifacts
-          mkdir artifacts/chao-test
-          mkdir artifacts/pulsar
-          current_dir=$PWD
-          kubectl -n pulsar-cluster logs chao-test > ${current_dir}/artifacts/chao-test/chao-test.log
-          ${{ env.REPO_PATH }}/scripts/cp-logs-from-kind.sh  ${current_dir}/artifacts/chao-test
-          kubectl -n pulsar-cluster logs pulsar-asp-broker-0 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-broker-1 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-0 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-1 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-2 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-2.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-0 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-1 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-2 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-2.log
-          kubectl -n pulsar-cluster exec pulsar-asp-broker-0 -- jmap -dump:live,format=b,file=/pulsar/heap-pulsar-asp-broker-0.bin 1
-          kubectl cp pulsar-cluster/pulsar-asp-broker-0:/pulsar/heap-pulsar-asp-broker-0.bin ${current_dir}/artifacts/pulsar/heap-pulsar-asp-broker-0.bin
-          kubectl -n pulsar-cluster exec pulsar-asp-broker-1 -- jmap -dump:live,format=b,file=/pulsar/heap-pulsar-asp-broker-1.bin 1
-          kubectl cp pulsar-cluster/pulsar-asp-broker-1:/pulsar/heap-pulsar-asp-broker-1.bin ${current_dir}/artifacts/pulsar/heap-pulsar-asp-broker-1.bin
-          zip -r artifacts-${{ matrix.test.name }}.zip artifacts
+        run: ${{ env.REPO_PATH }}/scripts/collect-artifacts.sh "${{ matrix.test.name }}" true
 
       - uses: actions/upload-artifact@v4
         name: upload reports
@@ -243,27 +223,7 @@ jobs:
 
       - name: package reports
         if: failure()
-        run: |
-          rm -rf artifacts
-          mkdir artifacts
-          mkdir artifacts/chao-test
-          mkdir artifacts/pulsar
-          current_dir=$PWD
-          kubectl -n pulsar-cluster logs chao-test > ${current_dir}/artifacts/chao-test/chao-test.log
-          ${{ env.REPO_PATH }}/scripts/cp-logs-from-kind.sh  ${current_dir}/artifacts/chao-test
-          kubectl -n pulsar-cluster logs pulsar-asp-broker-0 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-broker-1 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-0 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-1 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-2 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-2.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-0 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-1 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-2 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-2.log
-          kubectl -n pulsar-cluster exec pulsar-asp-broker-0 -- jmap -dump:live,format=b,file=/pulsar/heap-pulsar-asp-broker-0.bin 1
-          kubectl cp pulsar-cluster/pulsar-asp-broker-0:/pulsar/heap-pulsar-asp-broker-0.bin ${current_dir}/artifacts/pulsar/heap-pulsar-asp-broker-0.bin
-          kubectl -n pulsar-cluster exec pulsar-asp-broker-1 -- jmap -dump:live,format=b,file=/pulsar/heap-pulsar-asp-broker-1.bin 1
-          kubectl cp pulsar-cluster/pulsar-asp-broker-1:/pulsar/heap-pulsar-asp-broker-1.bin ${current_dir}/artifacts/pulsar/heap-pulsar-asp-broker-1.bin
-          zip -r artifacts-${{ matrix.test.name }}.zip artifacts
+        run: ${{ env.REPO_PATH }}/scripts/collect-artifacts.sh "${{ matrix.test.name }}" true
 
       - uses: actions/upload-artifact@v4
         name: upload reports
@@ -370,27 +330,7 @@ jobs:
 
       - name: package reports
         if: failure()
-        run: |
-          rm -rf artifacts
-          mkdir artifacts
-          mkdir artifacts/chao-test
-          mkdir artifacts/pulsar
-          current_dir=$PWD
-          kubectl -n pulsar-cluster logs chao-test > ${current_dir}/artifacts/chao-test/chao-test.log
-          ${{ env.REPO_PATH }}/scripts/cp-logs-from-kind.sh  ${current_dir}/artifacts/chao-test
-          kubectl -n pulsar-cluster logs pulsar-asp-broker-0 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-broker-1 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-0 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-1 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-2 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-2.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-0 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-1 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-2 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-2.log
-          kubectl -n pulsar-cluster exec pulsar-asp-broker-0 -- jmap -dump:live,format=b,file=/pulsar/heap-pulsar-asp-broker-0.bin 1
-          kubectl cp pulsar-cluster/pulsar-asp-broker-0:/pulsar/heap-pulsar-asp-broker-0.bin ${current_dir}/artifacts/pulsar/heap-pulsar-asp-broker-0.bin
-          kubectl -n pulsar-cluster exec pulsar-asp-broker-1 -- jmap -dump:live,format=b,file=/pulsar/heap-pulsar-asp-broker-1.bin 1
-          kubectl cp pulsar-cluster/pulsar-asp-broker-1:/pulsar/heap-pulsar-asp-broker-1.bin ${current_dir}/artifacts/pulsar/heap-pulsar-asp-broker-1.bin
-          zip -r artifacts-${{ matrix.test.name }}.zip artifacts
+        run: ${{ env.REPO_PATH }}/scripts/collect-artifacts.sh "${{ matrix.test.name }}" true
 
       - uses: actions/upload-artifact@v4
         name: upload reports

--- a/.github/workflows/kop-test.yml
+++ b/.github/workflows/kop-test.yml
@@ -111,7 +111,7 @@ jobs:
           #            chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-io-fault.yaml"
           #          },
           {
-            name: "eo-chaos-stress",
+            name: "alo-chaos-stress",
             chaos-mesh-config: "deploy/chaos-mesh/chaos-mesh-stress.yaml"
           },
           {
@@ -131,11 +131,6 @@ jobs:
           path: /tmp
       - name: Load chao-test image
         run: docker load --input /tmp/chao-test.tar
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.ASCENTSTREAM_DOCKER_USERNAME }}
-          password: ${{ secrets.ASCENTSTREAM_DOCKER_PASSWORD }}
 
       - uses: helm/kind-action@v1.5.0
         with:
@@ -232,11 +227,6 @@ jobs:
           path: /tmp
       - name: Load chao-test image
         run: docker load --input /tmp/chao-test.tar
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.ASCENTSTREAM_DOCKER_USERNAME }}
-          password: ${{ secrets.ASCENTSTREAM_DOCKER_PASSWORD }}
 
       - uses: helm/kind-action@v1.5.0
         with:
@@ -364,11 +354,6 @@ jobs:
           path: /tmp
       - name: Load chao-test image
         run: docker load --input /tmp/chao-test.tar
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.ASCENTSTREAM_DOCKER_USERNAME }}
-          password: ${{ secrets.ASCENTSTREAM_DOCKER_PASSWORD }}
 
       - uses: helm/kind-action@v1.5.0
         with:

--- a/.github/workflows/kop-test.yml
+++ b/.github/workflows/kop-test.yml
@@ -5,7 +5,7 @@ on:
       as-platform-image-tag:
         description: 'Please input as-platform image tag'
         required: true
-        default: '2.10.7.4'
+        default: '4.0.11.0'
         type: string
       send-msg-count:
         description: 'Please enter the number of messages to send'
@@ -31,7 +31,7 @@ env:
   GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
 
 jobs:
-  alt-chao:
+  alo-chao:
     runs-on: ubuntu-latest
     env:
       REPO_PATH: ${{ github.workspace }}
@@ -169,7 +169,7 @@ jobs:
           kubectl cp pulsar-cluster/pulsar-asp-broker-1:/pulsar/heap-pulsar-asp-broker-1.bin ${current_dir}/artifacts/pulsar/heap-pulsar-asp-broker-1.bin
           zip -r artifacts-${{ matrix.test.name }}.zip artifacts
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         name: upload reports
         if: failure()
         with:
@@ -274,7 +274,7 @@ jobs:
           kubectl cp pulsar-cluster/pulsar-asp-broker-1:/pulsar/heap-pulsar-asp-broker-1.bin ${current_dir}/artifacts/pulsar/heap-pulsar-asp-broker-1.bin
           zip -r artifacts-${{ matrix.test.name }}.zip artifacts
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         name: upload reports
         if: failure()
         with:
@@ -412,7 +412,7 @@ jobs:
           kubectl cp pulsar-cluster/pulsar-asp-broker-1:/pulsar/heap-pulsar-asp-broker-1.bin ${current_dir}/artifacts/pulsar/heap-pulsar-asp-broker-1.bin
           zip -r artifacts-${{ matrix.test.name }}.zip artifacts
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         name: upload reports
         if: failure()
         with:

--- a/.github/workflows/kop-test.yml
+++ b/.github/workflows/kop-test.yml
@@ -31,7 +31,34 @@ env:
   GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout chao-test codebase
+        uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+      - name: Build jar
+        run: mvn clean package
+      - name: Build docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          tags: chao-test:latest
+          outputs: type=docker,dest=/tmp/chao-test.tar
+      - name: Upload docker image
+        uses: actions/upload-artifact@v4
+        with:
+          name: chao-test-image
+          path: /tmp/chao-test.tar
+          retention-days: 1
+
   alo-chao:
+    needs: build
     runs-on: ubuntu-latest
     env:
       REPO_PATH: ${{ github.workspace }}
@@ -100,18 +127,13 @@ jobs:
       - name: Checkout chao-test codebase
         uses: actions/checkout@v3
 
-      - uses: actions/setup-java@v3
+      - name: Download chao-test image
+        uses: actions/download-artifact@v4
         with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
-      - name: Build
-        run: mvn clean package
-      - name: Build docker
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: false
-          tags: chao-test:latest
+          name: chao-test-image
+          path: /tmp
+      - name: Load chao-test image
+        run: docker load --input /tmp/chao-test.tar
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -177,6 +199,7 @@ jobs:
           path: artifacts-${{ matrix.test.name }}.zip
 
   idempotence-chao:
+    needs: build
     runs-on: ubuntu-latest
     env:
       REPO_PATH: ${{ github.workspace }}
@@ -205,18 +228,13 @@ jobs:
       - name: Checkout chao-test codebase
         uses: actions/checkout@v3
 
-      - uses: actions/setup-java@v3
+      - name: Download chao-test image
+        uses: actions/download-artifact@v4
         with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
-      - name: Build
-        run: mvn clean package
-      - name: Build docker
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: false
-          tags: chao-test:latest
+          name: chao-test-image
+          path: /tmp
+      - name: Load chao-test image
+        run: docker load --input /tmp/chao-test.tar
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -281,10 +299,9 @@ jobs:
           name: artifacts-${{ matrix.test.name }}
           path: artifacts-${{ matrix.test.name }}.zip
   eo-chao:
+    needs: build
     runs-on: ubuntu-latest
     env:
-      JAVA_VERSION: 17
-      JAVA_DISTRIBUTION: temurin
       REPO_PATH: ${{ github.workspace }}
       AS_PLATFORM_IMAGE_TAG: ${{ github.event.inputs.as-platform-image-tag }}
       REGISTRY_USERNAME: ${{ secrets.ASCENTSTREAM_DOCKER_USERNAME }}
@@ -343,18 +360,13 @@ jobs:
       - name: Checkout chao-test codebase
         uses: actions/checkout@v3
 
-      - uses: actions/setup-java@v3
+      - name: Download chao-test image
+        uses: actions/download-artifact@v4
         with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
-      - name: Build
-        run: mvn clean package
-      - name: Build docker
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: false
-          tags: chao-test:latest
+          name: chao-test-image
+          path: /tmp
+      - name: Load chao-test image
+        run: docker load --input /tmp/chao-test.tar
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/kop-test.yml
+++ b/.github/workflows/kop-test.yml
@@ -33,6 +33,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout chao-test codebase
         uses: actions/checkout@v4
@@ -57,6 +58,7 @@ jobs:
   alo-chao:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       REPO_PATH: ${{ github.workspace }}
       RELEASE_BRANCH: ${{ github.event.inputs.branch }}
@@ -149,6 +151,7 @@ jobs:
   idempotence-chao:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       REPO_PATH: ${{ github.workspace }}
       RELEASE_BRANCH: main
@@ -200,6 +203,7 @@ jobs:
   eo-chao:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       REPO_PATH: ${{ github.workspace }}
       AS_PLATFORM_IMAGE_TAG: ${{ github.event.inputs.as-platform-image-tag }}

--- a/.github/workflows/kop-test.yml
+++ b/.github/workflows/kop-test.yml
@@ -44,12 +44,9 @@ jobs:
       - name: Build jar
         run: mvn clean package
       - name: Build docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: false
-          tags: chao-test:latest
-          outputs: type=docker,dest=/tmp/chao-test.tar
+        run: |
+          docker build -t chao-test:latest .
+          docker save chao-test:latest -o /tmp/chao-test.tar
       - name: Upload docker image
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/kop-test.yml
+++ b/.github/workflows/kop-test.yml
@@ -161,27 +161,7 @@ jobs:
 
       - name: package reports
         if: failure()
-        run: |
-          rm -rf artifacts
-          mkdir artifacts
-          mkdir artifacts/chao-test
-          mkdir artifacts/pulsar
-          current_dir=$PWD
-          kubectl -n pulsar-cluster logs chao-test > ${current_dir}/artifacts/chao-test/chao-test.log
-          ${{ env.REPO_PATH }}/scripts/cp-logs-from-kind.sh  ${current_dir}/artifacts/chao-test
-          kubectl -n pulsar-cluster logs pulsar-asp-broker-0 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-broker-1 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-0 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-1 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-2 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-2.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-0 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-1 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-2 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-2.log
-          kubectl -n pulsar-cluster exec pulsar-asp-broker-0 -- jmap -dump:live,format=b,file=/pulsar/heap-pulsar-asp-broker-0.bin 1
-          kubectl cp pulsar-cluster/pulsar-asp-broker-0:/pulsar/heap-pulsar-asp-broker-0.bin ${current_dir}/artifacts/pulsar/heap-pulsar-asp-broker-0.bin
-          kubectl -n pulsar-cluster exec pulsar-asp-broker-1 -- jmap -dump:live,format=b,file=/pulsar/heap-pulsar-asp-broker-1.bin 1
-          kubectl cp pulsar-cluster/pulsar-asp-broker-1:/pulsar/heap-pulsar-asp-broker-1.bin ${current_dir}/artifacts/pulsar/heap-pulsar-asp-broker-1.bin
-          zip -r artifacts-${{ matrix.test.name }}.zip artifacts
+        run: ${{ env.REPO_PATH }}/scripts/collect-artifacts.sh "${{ matrix.test.name }}" true
 
       - uses: actions/upload-artifact@v4
         name: upload reports
@@ -257,27 +237,7 @@ jobs:
 
       - name: package reports
         if: failure()
-        run: |
-          rm -rf artifacts
-          mkdir artifacts
-          mkdir artifacts/chao-test
-          mkdir artifacts/pulsar
-          current_dir=$PWD
-          kubectl -n pulsar-cluster logs chao-test > ${current_dir}/artifacts/chao-test/chao-test.log
-          ${{ env.REPO_PATH }}/scripts/cp-logs-from-kind.sh  ${current_dir}/artifacts/chao-test
-          kubectl -n pulsar-cluster logs pulsar-asp-broker-0 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-broker-1 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-0 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-1 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-2 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-2.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-0 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-1 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-2 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-2.log
-          kubectl -n pulsar-cluster exec pulsar-asp-broker-0 -- jmap -dump:live,format=b,file=/pulsar/heap-pulsar-asp-broker-0.bin 1
-          kubectl cp pulsar-cluster/pulsar-asp-broker-0:/pulsar/heap-pulsar-asp-broker-0.bin ${current_dir}/artifacts/pulsar/heap-pulsar-asp-broker-0.bin
-          kubectl -n pulsar-cluster exec pulsar-asp-broker-1 -- jmap -dump:live,format=b,file=/pulsar/heap-pulsar-asp-broker-1.bin 1
-          kubectl cp pulsar-cluster/pulsar-asp-broker-1:/pulsar/heap-pulsar-asp-broker-1.bin ${current_dir}/artifacts/pulsar/heap-pulsar-asp-broker-1.bin
-          zip -r artifacts-${{ matrix.test.name }}.zip artifacts
+        run: ${{ env.REPO_PATH }}/scripts/collect-artifacts.sh "${{ matrix.test.name }}" true
 
       - uses: actions/upload-artifact@v4
         name: upload reports
@@ -384,27 +344,7 @@ jobs:
 
       - name: package reports
         if: failure()
-        run: |
-          rm -rf artifacts
-          mkdir artifacts
-          mkdir artifacts/chao-test
-          mkdir artifacts/pulsar
-          current_dir=$PWD
-          kubectl -n pulsar-cluster logs chao-test > ${current_dir}/artifacts/chao-test/chao-test.log
-          ${{ env.REPO_PATH }}/scripts/cp-logs-from-kind.sh  ${current_dir}/artifacts/chao-test
-          kubectl -n pulsar-cluster logs pulsar-asp-broker-0 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-broker-1 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-0 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-1 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-2 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-2.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-0 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-1 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-2 --since=0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-2.log
-          kubectl -n pulsar-cluster exec pulsar-asp-broker-0 -- jmap -dump:live,format=b,file=/pulsar/heap-pulsar-asp-broker-0.bin 1
-          kubectl cp pulsar-cluster/pulsar-asp-broker-0:/pulsar/heap-pulsar-asp-broker-0.bin ${current_dir}/artifacts/pulsar/heap-pulsar-asp-broker-0.bin
-          kubectl -n pulsar-cluster exec pulsar-asp-broker-1 -- jmap -dump:live,format=b,file=/pulsar/heap-pulsar-asp-broker-1.bin 1
-          kubectl cp pulsar-cluster/pulsar-asp-broker-1:/pulsar/heap-pulsar-asp-broker-1.bin ${current_dir}/artifacts/pulsar/heap-pulsar-asp-broker-1.bin
-          zip -r artifacts-${{ matrix.test.name }}.zip artifacts
+        run: ${{ env.REPO_PATH }}/scripts/collect-artifacts.sh "${{ matrix.test.name }}" true
 
       - uses: actions/upload-artifact@v4
         name: upload reports

--- a/.github/workflows/kop-test.yml
+++ b/.github/workflows/kop-test.yml
@@ -122,42 +122,18 @@ jobs:
 
     steps:
       - name: Checkout chao-test codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download chao-test image
         uses: actions/download-artifact@v4
         with:
           name: chao-test-image
           path: /tmp
-      - name: Load chao-test image
-        run: docker load --input /tmp/chao-test.tar
-
-      - uses: helm/kind-action@v1.5.0
+      - uses: ./.github/actions/run-chaos-test
         with:
-          cluster_name: kind
-          kubectl_version: v1.25.5
-
-      - name: deploy as-platform
-        run: ${{ env.REPO_PATH }}/scripts/ci.sh deploy_as_platform
-      - name: deploy chaos-mesh
-        run: |
-          curl -sSL https://mirrors.chaos-mesh.org/v2.7.0/install.sh | bash -s -- --local kind --kind-version v0.17.0 --name kind  --k8s-version  1.25.3
-          kubectl get pod  -n chaos-mesh
-      - name: ${{ matrix.test.name }}
-        run: |
-          kind load docker-image chao-test:latest
-          ${{ env.REPO_PATH }}/scripts/run-chao-test.sh
-          kubectl -n pulsar-cluster get pods
-      - name: injecting faults
-        run: |
-          sleep 30
-          kubectl -n chaos-mesh apply -f ${{ matrix.test.chaos-mesh-config }}
-          echo "get chaos-mesh workflow "
-          kubectl -n chaos-mesh get workflow
-          echo "get chaos-mesh workflownode "
-          kubectl -n chaos-mesh get workflownode --selector="chaos-mesh.org/workflow=asp-platform"
-      - name: Wait for workflow completion
-        run:  ${{ env.REPO_PATH }}/scripts/wait-workflow-completion.sh
+          test-name: ${{ matrix.test.name }}
+          chaos-mesh-config: ${{ matrix.test.chaos-mesh-config }}
+          repo-path: ${{ env.REPO_PATH }}
 
       - name: package reports
         if: failure()
@@ -198,42 +174,18 @@ jobs:
 
     steps:
       - name: Checkout chao-test codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download chao-test image
         uses: actions/download-artifact@v4
         with:
           name: chao-test-image
           path: /tmp
-      - name: Load chao-test image
-        run: docker load --input /tmp/chao-test.tar
-
-      - uses: helm/kind-action@v1.5.0
+      - uses: ./.github/actions/run-chaos-test
         with:
-          cluster_name: kind
-          kubectl_version: v1.25.5
-
-      - name: deploy as-platform
-        run: ${{ env.REPO_PATH }}/scripts/ci.sh deploy_as_platform
-      - name: deploy chaos-mesh
-        run: |
-          curl -sSL https://mirrors.chaos-mesh.org/v2.7.0/install.sh | bash -s -- --local kind --kind-version v0.17.0 --name kind  --k8s-version  1.25.3
-          kubectl get pod  -n chaos-mesh
-      - name: ${{ matrix.test.name }}
-        run: |
-          kind load docker-image chao-test:latest
-          ${{ env.REPO_PATH }}/scripts/run-chao-test.sh
-          kubectl -n pulsar-cluster get pods
-      - name: injecting faults
-        run: |
-          sleep 30
-          kubectl -n chaos-mesh apply -f ${{ matrix.test.chaos-mesh-config }}
-          echo "get chaos-mesh workflow "
-          kubectl -n chaos-mesh get workflow
-          echo "get chaos-mesh workflownode "
-          kubectl -n chaos-mesh get workflownode --selector="chaos-mesh.org/workflow=asp-platform"
-      - name: Wait for workflow completion
-        run: ${{ env.REPO_PATH }}/scripts/wait-workflow-completion.sh
+          test-name: ${{ matrix.test.name }}
+          chaos-mesh-config: ${{ matrix.test.chaos-mesh-config }}
+          repo-path: ${{ env.REPO_PATH }}
 
       - name: package reports
         if: failure()
@@ -305,42 +257,18 @@ jobs:
 
     steps:
       - name: Checkout chao-test codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download chao-test image
         uses: actions/download-artifact@v4
         with:
           name: chao-test-image
           path: /tmp
-      - name: Load chao-test image
-        run: docker load --input /tmp/chao-test.tar
-
-      - uses: helm/kind-action@v1.5.0
+      - uses: ./.github/actions/run-chaos-test
         with:
-          cluster_name: kind
-          kubectl_version: v1.25.5
-
-      - name: deploy as-platform
-        run: ${{ env.REPO_PATH }}/scripts/ci.sh deploy_as_platform
-      - name: deploy chaos-mesh
-        run: |
-          curl -sSL https://mirrors.chaos-mesh.org/v2.7.0/install.sh | bash -s -- --local kind --kind-version v0.17.0 --name kind  --k8s-version  1.25.3
-          kubectl get pod  -n chaos-mesh
-      - name: ${{ matrix.test.name }}
-        run: |
-          kind load docker-image chao-test:latest
-          ${{ env.REPO_PATH }}/scripts/run-chao-test.sh
-          kubectl -n pulsar-cluster get pods
-      - name: injecting faults
-        run: |
-          sleep 30
-          kubectl -n chaos-mesh apply -f ${{ matrix.test.chaos-mesh-config }}
-          echo "get chaos-mesh workflow "
-          kubectl -n chaos-mesh get workflow
-          echo "get chaos-mesh workflownode "
-          kubectl -n chaos-mesh get workflownode --selector="chaos-mesh.org/workflow=asp-platform"
-      - name: Wait for workflow completion
-        run: ${{ env.REPO_PATH }}/scripts/wait-workflow-completion.sh
+          test-name: ${{ matrix.test.name }}
+          chaos-mesh-config: ${{ matrix.test.chaos-mesh-config }}
+          repo-path: ${{ env.REPO_PATH }}
 
       - name: package reports
         if: failure()

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -15,11 +15,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout chao-test codebase
+        uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+      - name: Build jar
+        run: mvn clean package
+      - name: Build docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          tags: chao-test:latest
+          outputs: type=docker,dest=/tmp/chao-test.tar
+      - name: Upload docker image
+        uses: actions/upload-artifact@v4
+        with:
+          name: chao-test-image
+          path: /tmp/chao-test.tar
+          retention-days: 1
+
   alo-chao:
+    needs: build
     runs-on: ubuntu-latest
     env:
-      JAVA_VERSION: 17
-      JAVA_DISTRIBUTION: temurin
       REPO_PATH: ${{ github.workspace }}
       AS_PLATFORM_IMAGE_TAG: chao-test-latest
       REGISTRY_USERNAME: ${{ secrets.ASCENTSTREAM_DOCKER_USERNAME }}
@@ -85,18 +110,13 @@ jobs:
       - name: Checkout chao-test codebase
         uses: actions/checkout@v3
 
-      - uses: actions/setup-java@v3
+      - name: Download chao-test image
+        uses: actions/download-artifact@v4
         with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
-      - name: Build
-        run: mvn clean package
-      - name: Build docker
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: false
-          tags: chao-test:latest
+          name: chao-test-image
+          path: /tmp
+      - name: Load chao-test image
+        run: docker load --input /tmp/chao-test.tar
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -157,10 +177,9 @@ jobs:
           name: artifacts-${{ matrix.test.name }}
           path: artifacts-${{ matrix.test.name }}.zip
   idempotence-chao:
+    needs: build
     runs-on: ubuntu-latest
     env:
-      JAVA_VERSION: 17
-      JAVA_DISTRIBUTION: temurin
       REPO_PATH: ${{ github.workspace }}
       AS_PLATFORM_IMAGE_TAG: chao-test-latest
       REGISTRY_USERNAME: ${{ secrets.ASCENTSTREAM_DOCKER_USERNAME }}
@@ -186,18 +205,13 @@ jobs:
       - name: Checkout chao-test codebase
         uses: actions/checkout@v3
 
-      - uses: actions/setup-java@v3
+      - name: Download chao-test image
+        uses: actions/download-artifact@v4
         with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
-      - name: Build
-        run: mvn clean package
-      - name: Build docker
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: false
-          tags: chao-test:latest
+          name: chao-test-image
+          path: /tmp
+      - name: Load chao-test image
+        run: docker load --input /tmp/chao-test.tar
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -259,10 +273,9 @@ jobs:
           path: artifacts-${{ matrix.test.name }}.zip
 
   eo-chao:
+    needs: build
     runs-on: ubuntu-latest
     env:
-      JAVA_VERSION: 17
-      JAVA_DISTRIBUTION: temurin
       REPO_PATH: ${{ github.workspace }}
       AS_PLATFORM_IMAGE_TAG: chao-test-latest
       REGISTRY_USERNAME: ${{ secrets.ASCENTSTREAM_DOCKER_USERNAME }}
@@ -321,18 +334,13 @@ jobs:
       - name: Checkout chao-test codebase
         uses: actions/checkout@v3
 
-      - uses: actions/setup-java@v3
+      - name: Download chao-test image
+        uses: actions/download-artifact@v4
         with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
-      - name: Build
-        run: mvn clean package
-      - name: Build docker
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: false
-          tags: chao-test:latest
+          name: chao-test-image
+          path: /tmp
+      - name: Load chao-test image
+        run: docker load --input /tmp/chao-test.tar
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -105,42 +105,18 @@ jobs:
 
     steps:
       - name: Checkout chao-test codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download chao-test image
         uses: actions/download-artifact@v4
         with:
           name: chao-test-image
           path: /tmp
-      - name: Load chao-test image
-        run: docker load --input /tmp/chao-test.tar
-
-      - uses: helm/kind-action@v1.5.0
+      - uses: ./.github/actions/run-chaos-test
         with:
-          cluster_name: kind
-          kubectl_version: v1.25.5
-
-      - name: deploy as-platform
-        run: ${{ env.REPO_PATH }}/scripts/ci.sh deploy_as_platform
-      - name: deploy chaos-mesh
-        run: |
-          curl -sSL https://mirrors.chaos-mesh.org/v2.7.0/install.sh | bash -s -- --local kind --kind-version v0.17.0 --name kind  --k8s-version  1.25.3
-          kubectl get pod  -n chaos-mesh
-      - name: ${{ matrix.test.name }}
-        run: |
-          kind load docker-image chao-test:latest
-          ${{ env.REPO_PATH }}/scripts/run-chao-test.sh
-          kubectl -n pulsar-cluster get pods
-      - name: injecting faults
-        run: |
-          sleep 30
-          kubectl -n chaos-mesh apply -f ${{ matrix.test.chaos-mesh-config }}
-          echo "get chaos-mesh workflow "
-          kubectl -n chaos-mesh get workflow
-          echo "get chaos-mesh workflownode "
-          kubectl -n chaos-mesh get workflownode --selector="chaos-mesh.org/workflow=asp-platform"
-      - name: Wait for workflow completion
-        run:  ${{ env.REPO_PATH }}/scripts/wait-workflow-completion.sh
+          test-name: ${{ matrix.test.name }}
+          chaos-mesh-config: ${{ matrix.test.chaos-mesh-config }}
+          repo-path: ${{ env.REPO_PATH }}
 
       - name: package reports
         if: failure()
@@ -179,42 +155,18 @@ jobs:
 
     steps:
       - name: Checkout chao-test codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download chao-test image
         uses: actions/download-artifact@v4
         with:
           name: chao-test-image
           path: /tmp
-      - name: Load chao-test image
-        run: docker load --input /tmp/chao-test.tar
-
-      - uses: helm/kind-action@v1.5.0
+      - uses: ./.github/actions/run-chaos-test
         with:
-          cluster_name: kind
-          kubectl_version: v1.25.5
-
-      - name: deploy as-platform
-        run: ${{ env.REPO_PATH }}/scripts/ci.sh deploy_as_platform
-      - name: deploy chaos-mesh
-        run: |
-          curl -sSL https://mirrors.chaos-mesh.org/v2.7.0/install.sh | bash -s -- --local kind --kind-version v0.17.0 --name kind  --k8s-version  1.25.3
-          kubectl get pod  -n chaos-mesh
-      - name: ${{ matrix.test.name }}
-        run: |
-          kind load docker-image chao-test:latest
-          ${{ env.REPO_PATH }}/scripts/run-chao-test.sh
-          kubectl -n pulsar-cluster get pods
-      - name: injecting faults
-        run: |
-          sleep 30
-          kubectl -n chaos-mesh apply -f ${{ matrix.test.chaos-mesh-config }}
-          echo "get chaos-mesh workflow "
-          kubectl -n chaos-mesh get workflow
-          echo "get chaos-mesh workflownode "
-          kubectl -n chaos-mesh get workflownode --selector="chaos-mesh.org/workflow=asp-platform"
-      - name: Wait for workflow completion
-        run: ${{ env.REPO_PATH }}/scripts/wait-workflow-completion.sh
+          test-name: ${{ matrix.test.name }}
+          chaos-mesh-config: ${{ matrix.test.chaos-mesh-config }}
+          repo-path: ${{ env.REPO_PATH }}
 
       - name: package reports
         if: failure()
@@ -287,42 +239,18 @@ jobs:
 
     steps:
       - name: Checkout chao-test codebase
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download chao-test image
         uses: actions/download-artifact@v4
         with:
           name: chao-test-image
           path: /tmp
-      - name: Load chao-test image
-        run: docker load --input /tmp/chao-test.tar
-
-      - uses: helm/kind-action@v1.5.0
+      - uses: ./.github/actions/run-chaos-test
         with:
-          cluster_name: kind
-          kubectl_version: v1.25.5
-
-      - name: deploy as-platform
-        run: ${{ env.REPO_PATH }}/scripts/ci.sh deploy_as_platform
-      - name: deploy chaos-mesh
-        run: |
-          curl -sSL https://mirrors.chaos-mesh.org/v2.7.0/install.sh | bash -s -- --local kind --kind-version v0.17.0 --name kind  --k8s-version  1.25.3
-          kubectl get pod  -n chaos-mesh
-      - name: ${{ matrix.test.name }}
-        run: |
-          kind load docker-image chao-test:latest
-          ${{ env.REPO_PATH }}/scripts/run-chao-test.sh
-          kubectl -n pulsar-cluster get pods
-      - name: injecting faults
-        run: |
-          sleep 30
-          kubectl -n chaos-mesh apply -f ${{ matrix.test.chaos-mesh-config }}
-          echo "get chaos-mesh workflow "
-          kubectl -n chaos-mesh get workflow
-          echo "get chaos-mesh workflownode "
-          kubectl -n chaos-mesh get workflownode --selector="chaos-mesh.org/workflow=asp-platform"
-      - name: Wait for workflow completion
-        run: ${{ env.REPO_PATH }}/scripts/wait-workflow-completion.sh
+          test-name: ${{ matrix.test.name }}
+          chaos-mesh-config: ${{ matrix.test.chaos-mesh-config }}
+          repo-path: ${{ env.REPO_PATH }}
 
       - name: package reports
         if: failure()

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -114,11 +114,6 @@ jobs:
           path: /tmp
       - name: Load chao-test image
         run: docker load --input /tmp/chao-test.tar
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.ASCENTSTREAM_DOCKER_USERNAME }}
-          password: ${{ secrets.ASCENTSTREAM_DOCKER_PASSWORD }}
 
       - uses: helm/kind-action@v1.5.0
         with:
@@ -209,11 +204,6 @@ jobs:
           path: /tmp
       - name: Load chao-test image
         run: docker load --input /tmp/chao-test.tar
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.ASCENTSTREAM_DOCKER_USERNAME }}
-          password: ${{ secrets.ASCENTSTREAM_DOCKER_PASSWORD }}
 
       - uses: helm/kind-action@v1.5.0
         with:
@@ -338,11 +328,6 @@ jobs:
           path: /tmp
       - name: Load chao-test image
         run: docker load --input /tmp/chao-test.tar
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.ASCENTSTREAM_DOCKER_USERNAME }}
-          password: ${{ secrets.ASCENTSTREAM_DOCKER_PASSWORD }}
 
       - uses: helm/kind-action@v1.5.0
         with:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -150,7 +150,7 @@ jobs:
           kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-2 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-2.log
           zip -r artifacts-${{ matrix.test.name }}.zip artifacts
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         name: upload reports
         if: failure()
         with:
@@ -251,7 +251,7 @@ jobs:
           kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-2 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-2.log
           zip -r artifacts-${{ matrix.test.name }}.zip artifacts
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         name: upload reports
         if: failure()
         with:
@@ -386,7 +386,7 @@ jobs:
           kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-2 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-2.log
           zip -r artifacts-${{ matrix.test.name }}.zip artifacts
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         name: upload reports
         if: failure()
         with:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -144,23 +144,7 @@ jobs:
 
       - name: package reports
         if: failure()
-        run: |
-          rm -rf artifacts
-          mkdir artifacts
-          mkdir artifacts/chao-test
-          mkdir artifacts/pulsar
-          current_dir=$PWD
-          kubectl -n pulsar-cluster logs chao-test > ${current_dir}/artifacts/chao-test/chao-test.log
-          ${{ env.REPO_PATH }}/scripts/cp-logs-from-kind.sh  ${current_dir}/artifacts/chao-test
-          kubectl -n pulsar-cluster logs pulsar-asp-broker-0 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-broker-1 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-1 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-2 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-2.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-1 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-2 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-2.log
-          zip -r artifacts-${{ matrix.test.name }}.zip artifacts
+        run: ${{ env.REPO_PATH }}/scripts/collect-artifacts.sh "${{ matrix.test.name }}"
 
       - uses: actions/upload-artifact@v4
         name: upload reports
@@ -234,23 +218,7 @@ jobs:
 
       - name: package reports
         if: failure()
-        run: |
-          rm -rf artifacts
-          mkdir artifacts
-          mkdir artifacts/chao-test
-          mkdir artifacts/pulsar
-          current_dir=$PWD
-          kubectl -n pulsar-cluster logs chao-test > ${current_dir}/artifacts/chao-test/chao-test.log
-          ${{ env.REPO_PATH }}/scripts/cp-logs-from-kind.sh  ${current_dir}/artifacts/chao-test
-          kubectl -n pulsar-cluster logs pulsar-asp-broker-0 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-broker-1 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-1 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-2 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-2.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-1 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-2 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-2.log
-          zip -r artifacts-${{ matrix.test.name }}.zip artifacts
+        run: ${{ env.REPO_PATH }}/scripts/collect-artifacts.sh "${{ matrix.test.name }}"
 
       - uses: actions/upload-artifact@v4
         name: upload reports
@@ -358,23 +326,7 @@ jobs:
 
       - name: package reports
         if: failure()
-        run: |
-          rm -rf artifacts
-          mkdir artifacts
-          mkdir artifacts/chao-test
-          mkdir artifacts/pulsar
-          current_dir=$PWD
-          kubectl -n pulsar-cluster logs chao-test > ${current_dir}/artifacts/chao-test/chao-test.log
-          ${{ env.REPO_PATH }}/scripts/cp-logs-from-kind.sh  ${current_dir}/artifacts/chao-test
-          kubectl -n pulsar-cluster logs pulsar-asp-broker-0 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-broker-1 > ${current_dir}/artifacts/pulsar/pulsar-asp-broker-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-0 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-1 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-bookie-2 > ${current_dir}/artifacts/pulsar/pulsar-asp-bookie-2.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-0 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-0.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-1 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-1.log
-          kubectl -n pulsar-cluster logs pulsar-asp-zookeeper-2 > ${current_dir}/artifacts/pulsar/pulsar-asp-zookeeper-2.log
-          zip -r artifacts-${{ matrix.test.name }}.zip artifacts
+        run: ${{ env.REPO_PATH }}/scripts/collect-artifacts.sh "${{ matrix.test.name }}"
 
       - uses: actions/upload-artifact@v4
         name: upload reports

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout chao-test codebase
         uses: actions/checkout@v4
@@ -41,6 +42,7 @@ jobs:
   alo-chao:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       REPO_PATH: ${{ github.workspace }}
       AS_PLATFORM_IMAGE_TAG: chao-test-latest
@@ -131,6 +133,7 @@ jobs:
   idempotence-chao:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       REPO_PATH: ${{ github.workspace }}
       AS_PLATFORM_IMAGE_TAG: chao-test-latest
@@ -182,6 +185,7 @@ jobs:
   eo-chao:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       REPO_PATH: ${{ github.workspace }}
       AS_PLATFORM_IMAGE_TAG: chao-test-latest

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -28,12 +28,9 @@ jobs:
       - name: Build jar
         run: mvn clean package
       - name: Build docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: false
-          tags: chao-test:latest
-          outputs: type=docker,dest=/tmp/chao-test.tar
+        run: |
+          docker build -t chao-test:latest .
+          docker save chao-test:latest -o /tmp/chao-test.tar
       - name: Upload docker image
         uses: actions/upload-artifact@v4
         with:

--- a/deploy/chart/asp-platform/asp-values.yaml
+++ b/deploy/chart/asp-platform/asp-values.yaml
@@ -1117,7 +1117,7 @@ broker:
   #    - my-pulsar-service-aop.example.com
   #    - my-pulsar-service-mop.example.com
   kop:
-    enabled: false
+    enabled: true
     tls:
       enabled: false
       # trustCertsEnabled controls the kop configuration item kopSslTruststoreLocation=/xxx/truststore.jks

--- a/scripts/collect-artifacts.sh
+++ b/scripts/collect-artifacts.sh
@@ -53,7 +53,9 @@ for role in broker bookie zookeeper; do
     echo "  logs: $pod_name"
     kubectl -n "$NAMESPACE" logs "$pod_name" $LOG_FLAGS \
       > "$CURRENT_DIR/artifacts/pulsar/$pod_name.log" 2>&1 || true
-  done < <(kubectl -n "$NAMESPACE" get pods -l "app=pulsar-asp-${role}" -o name 2>/dev/null)
+  done < <(kubectl -n "$NAMESPACE" get pods \
+            -l "cluster=pulsar-asp,component=${role},!job-name" \
+            -o name 2>/dev/null)
 done
 
 # 3. Optional heap dumps from broker pods (kop-test / per-hour)
@@ -67,7 +69,7 @@ if [ "$WITH_HEAP" == "true" ]; then
       jmap -dump:live,format=b,file="$heap_path" 1 || true
     kubectl cp "$NAMESPACE/${pod_name}:${heap_path}" \
       "$CURRENT_DIR/artifacts/pulsar/heap-${pod_name}.bin" || true
-  done < <(kubectl -n "$NAMESPACE" get pods -l "app=pulsar-asp-broker" -o name 2>/dev/null)
+  done < <(kubectl -n "$NAMESPACE" get pods -l "cluster=pulsar-asp,component=broker" -o name 2>/dev/null)
 fi
 
 # 4. Zip everything for upload-artifact

--- a/scripts/collect-artifacts.sh
+++ b/scripts/collect-artifacts.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Collect diagnostic artifacts (logs, optional heap dumps) from the
+# pulsar-cluster namespace and bundle them into artifacts-<test>.zip.
+#
+# Usage:
+#   collect-artifacts.sh <test-name> [with-heap-dump]
+#
+# Arguments:
+#   test-name        - name of the matrix case, used in the output zip filename
+#   with-heap-dump   - optional, "true" to also capture jmap heap dumps
+#                      from broker pods (used by kop-test / kop-test-per-hour)
+#
+# Environment:
+#   REPO_PATH        - repository root (to locate cp-logs-from-kind.sh)
+
+set -u
+
+TEST_NAME=${1:?usage: collect-artifacts.sh <test-name> [with-heap-dump]}
+WITH_HEAP=${2:-false}
+NAMESPACE=pulsar-cluster
+CURRENT_DIR=$PWD
+
+if [ -z "${REPO_PATH:-}" ]; then
+  echo "REPO_PATH is not set; falling back to \$(pwd)/.."
+  REPO_PATH="$(cd "$(dirname "$0")/.." && pwd)"
+fi
+
+echo "=== Collecting artifacts for test: $TEST_NAME (heap-dump: $WITH_HEAP) ==="
+
+rm -rf artifacts
+mkdir -p artifacts/chao-test artifacts/pulsar
+
+# 1. chao-test pod logs + anything cp-logs-from-kind.sh pulls out of kind
+kubectl -n "$NAMESPACE" logs chao-test > "$CURRENT_DIR/artifacts/chao-test/chao-test.log" 2>&1 || true
+if [ -x "$REPO_PATH/scripts/cp-logs-from-kind.sh" ]; then
+  "$REPO_PATH/scripts/cp-logs-from-kind.sh" "$CURRENT_DIR/artifacts/chao-test" || true
+fi
+
+# 2. Per-pod logs for broker / bookie / zookeeper via label selector
+#    (resilient to replica count changes - was previously hardcoded to
+#     broker-0/1, bookie-0/1/2, zookeeper-0/1/2)
+LOG_FLAGS=""
+if [ "$WITH_HEAP" == "true" ]; then
+  # kop-test / per-hour use --since=0 to capture the full log buffer
+  LOG_FLAGS="--since=0"
+fi
+
+for role in broker bookie zookeeper; do
+  while IFS= read -r pod; do
+    [ -z "$pod" ] && continue
+    pod_name=${pod#pod/}
+    echo "  logs: $pod_name"
+    kubectl -n "$NAMESPACE" logs "$pod_name" $LOG_FLAGS \
+      > "$CURRENT_DIR/artifacts/pulsar/$pod_name.log" 2>&1 || true
+  done < <(kubectl -n "$NAMESPACE" get pods -l "app=pulsar-asp-${role}" -o name 2>/dev/null)
+done
+
+# 3. Optional heap dumps from broker pods (kop-test / per-hour)
+if [ "$WITH_HEAP" == "true" ]; then
+  while IFS= read -r pod; do
+    [ -z "$pod" ] && continue
+    pod_name=${pod#pod/}
+    heap_path="/pulsar/heap-${pod_name}.bin"
+    echo "  heap dump: $pod_name"
+    kubectl -n "$NAMESPACE" exec "$pod_name" -- \
+      jmap -dump:live,format=b,file="$heap_path" 1 || true
+    kubectl cp "$NAMESPACE/${pod_name}:${heap_path}" \
+      "$CURRENT_DIR/artifacts/pulsar/heap-${pod_name}.bin" || true
+  done < <(kubectl -n "$NAMESPACE" get pods -l "app=pulsar-asp-broker" -o name 2>/dev/null)
+fi
+
+# 4. Zip everything for upload-artifact
+zip -r "artifacts-${TEST_NAME}.zip" artifacts >/dev/null
+echo "=== Built artifacts-${TEST_NAME}.zip ==="


### PR DESCRIPTION
## Summary

- Flip `broker.kop.enabled` from `false` to `true` in `asp-values.yaml`.

## Why

chao-test exercises Kafka-on-Pulsar (KoP) scenarios (`alo-*`, `eo-*`,
`idempotence-*` matrix jobs all hit `pulsar-asp-broker-headless:9092`),
but after PR #6 the flag was still `false`, so the KoP listener never
started and Kafka clients could not connect.

## Test plan

- [ ] `helm template` renders with kop.enabled=true
- [ ] `kubectl -n pulsar-cluster get pulsarasp -o yaml` shows kop config applied
- [ ] `pulsar-asp-broker-0/1` expose 9092
- [ ] `alo-normal` chaos test job connects via Kafka protocol and sends/receives messages